### PR TITLE
Add Python requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,6 @@
+elasticsearch==7.12.0
+kafka-python==2.0.2
+Keras==2.4.3
+pandas==1.2.4
+tensorflow==2.4.1
+tweepy==3.10.0

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -3,3 +3,4 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /home/ec2-user/kafka/bin/kafka-topics.sh --create --topic tweets --bootstrap-server localhost:9092
 /home/ec2-user/kafka/bin/kafka-topics.sh --create --topic processed_tweets --bootstrap-server localhost:9092
 git clone https://github.com/chrisbombino/cs631-project.git /home/ec2-user/cs631-project
+python3 -m pip install -r /home/ec2-user/cs631-project/scripts/requirements.txt


### PR DESCRIPTION
To make installation of dependencies easier, we will use requirements.txt
to install pip packages. This will be invoked at build time with
python3 -m pip install -r requirements.txt