### PR TITLE
Create Documentation for Configuring Custom AMI

### DIFF
--- a/docs/kafka.service
+++ b/docs/kafka.service
@@ -1,0 +1,13 @@
+[Unit]
+Requires=zookeeper.service
+After=zookeeper.service
+
+[Service]
+Type=simple
+User=ec2-user
+ExecStart=/bin/sh -c '/home/ec2-user/kafka/bin/kafka-server-start.sh /home/ec2-user/kafka/config/server.properties > /home/ec2-user/kafka/kafka.log 2>&1'
+ExecStop=/home/ec2-user/kafka/bin/kafka-server-stop.sh
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,52 @@
+# AWS AMI Configuration
+The configuration of the server is being done on a custom AMI that was made from a basic Amazon Linux 2 image. The AMI configuration can be replicated based on the following steps:
+
+All commands are run as default ec2-user
+
+### Dependencies
+`sudo yum update -y`
+
+`sudo yum install git -y`
+
+`sudo yum install python37 python3-pip -y`
+
+
+## Kafka
+Download JRE
+
+`sudo amazon-linux-extras install java-openjdk11 -y`
+
+Download kafka
+
+`wget https://mirror.its.dal.ca/apache/kafka/2.7.0/kafka_2.13-2.7.0.tgz`
+
+Extract tarball
+
+`tar -xvf kafka_2.13-2.7.0.tgz && mv kafka_2.13-2.7.0 /home/ec2-user/kafka && rm -f kafka_2.13-2.7.0.tgz && cd /home/ec2-user/kafka`
+
+Place zookeeper.service and kafka.service inside `/etc/systemd/system/` directory (see this [Digital Ocean](https://www.digitalocean.com/community/tutorials/how-to-install-apache-kafka-on-ubuntu-18-04) article for more details)
+
+`sudo systemctl enable kafka`
+
+
+## Elasticsearch & Kibana
+
+Install Elasticsearch package
+
+`sudo rpm -i https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.12.0-x86_64.rpm`
+
+`sudo systemctl enable elasticsearch`
+
+Install Kibana
+
+`sudo rpm -i https://artifacts.elastic.co/downloads/kibana/kibana-7.12.0-x86_64.rpm`
+
+`sudo systemctl enable kibana`
+
+Set the following in `/etc/kibana/kibana.yml`
+
+`server.port: 5601`
+
+`server.host: "0.0.0.0"`
+
+`elasticsearch.hosts: ["http://localhost:9200"]`

--- a/docs/zookeeper.service
+++ b/docs/zookeeper.service
@@ -1,0 +1,13 @@
+[Unit]
+Requires=network.target remote-fs.target
+After=network.target remote-fs.target
+
+[Service]
+Type=simple
+User=ec2-user
+ExecStart=/home/ec2-user/kafka/bin/zookeeper-server-start.sh /home/ec2-user/kafka/config/zookeeper.properties
+ExecStop=/home/ec2-user/kafka/bin/zookeeper-server-stop.sh
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
For this project we need quite a bit of software installed and configured.
To make this easier we have created a custom AMI to be used by Terraform in
the actual deployments.

This configuration will allow us to use Kafka as a systemd service, elasticsearch,
kibana, and Python. See setup.md for further details.