### PR TITLE
Add Topic Creation to AMI & Set Elasticsearch Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+*.auth

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,6 +28,10 @@ Place zookeeper.service and kafka.service inside `/etc/systemd/system/` director
 
 `sudo systemctl enable kafka`
 
+`/home/ec2-user/kafka/bin/kafka-topics.sh --create --topic tweets --bootstrap-server localhost:9092`
+`/home/ec2-user/kafka/bin/kafka-topics.sh --create --topic processed_tweets --bootstrap-server localhost:9092`
+
+
 
 ## Elasticsearch & Kibana
 
@@ -36,6 +40,20 @@ Install Elasticsearch package
 `sudo rpm -i https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.12.0-x86_64.rpm`
 
 `sudo systemctl enable elasticsearch`
+
+Enable passwords for built-in users
+
+`/usr/share/elasticsearch/bin/elasticsearch-setup-password auto`
+
+Set the following in `/etc/elasticsearch/elasticsearch.yml`
+
+`xpack.security.enabled: true`
+
+Export elastic users's password as es_password
+
+`echo "export ES_PASS=<ELASTIC_USER_PASSWORD>" > /etc/profile.d/es_pass.sh`
+
+Take note of kibana_system password
 
 Install Kibana
 
@@ -50,3 +68,5 @@ Set the following in `/etc/kibana/kibana.yml`
 `server.host: "0.0.0.0"`
 
 `elasticsearch.hosts: ["http://localhost:9200"]`
+
+`elasticsearch.password: <KIBANA_SYSTEM_PASSWORD>`

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -1,6 +1,8 @@
 #! /bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/home/ec2-user/kafka/bin/kafka-topics.sh --create --topic tweets --bootstrap-server localhost:9092
-/home/ec2-user/kafka/bin/kafka-topics.sh --create --topic processed_tweets --bootstrap-server localhost:9092
 git clone https://github.com/chrisbombino/cs631-project.git /home/ec2-user/cs631-project
 python3 -m pip install -r /home/ec2-user/cs631-project/scripts/requirements.txt
+cd /home/ec2-user/cs631-project/scripts
+nohup python3 /home/ec2-user/cs631-project/scripts/producer_twitter_streaming_api.py &
+nohup python3 /home/ec2-user/cs631-project/scripts/consumer_sentiment_analyzer.py &
+nohup python3 /home/ec2-user/cs631-project/scripts/consumer_elasticsearch.py &


### PR DESCRIPTION
Since the Kafka topics will be the same for every deployment, they
should be in the AMI instead of created at build time.

Also, since we need create custom users to use in Kibana, some extra
steps need to be taken to setup authentication.